### PR TITLE
Convert all issue IDs to uppercase

### DIFF
--- a/jira-bot.go
+++ b/jira-bot.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/nlopes/slack"
 	gojira "github.com/plouc/go-jira-client"
@@ -141,6 +142,8 @@ func extractIssueIDs(message string) []string {
 	result := []string{}
 
 	for v := range matches {
+		// convert all match to upper case.
+		matches[v] = strings.ToUpper(matches[v])
 		if encountered[matches[v]] == true {
 			// Do not add duplicate.
 		} else {

--- a/jira-bot_test.go
+++ b/jira-bot_test.go
@@ -35,7 +35,7 @@ func TestExtractMultipleIssueIDs(t *testing.T) {
 }
 
 func TestExtractIssueIDUniques(t *testing.T) {
-	result := extractIssueIDs("ABC-123 ABC-123 ABC-123 ABC-123 ABC-123 ABC-123")
+	result := extractIssueIDs("ABC-123 ABC-123 ABC-123 ABC-123 ABC-123 ABC-123 abc-123 aBc-123")
 
 	if len(result) != 1 {
 		t.Errorf("Expected one result, got %v", len(result))


### PR DESCRIPTION
Converting to uppercase fixes #3 where issues mentioned in mixed case appear twice.
